### PR TITLE
Support zstandard archives

### DIFF
--- a/pacman-fix-permissions
+++ b/pacman-fix-permissions
@@ -25,6 +25,13 @@ if hasattr(args, 'packages') and getattr(args, 'packages') == []:
 if hasattr(args, 'filesystem-paths') and getattr(args, 'f') == []:
     parser.error('You must pass at least one filesystem path when using -f switch')
 
+def zflat(p):
+    import zstd
+    # this is dirty, fh and reader are never closed.
+    fh = open(p, 'rb')
+    dctx = zstd.ZstdDecompressor()
+    reader = dctx.stream_reader(fh)
+    return reader
 
 def getTar(pkg):
     def _open():
@@ -34,6 +41,13 @@ def getTar(pkg):
             return tarfile.open(p_arch)
         if isfile(p_any):
             return tarfile.open(p_any)
+
+        p_arch = '/var/cache/pacman/pkg/{}-{}-{}.pkg.tar.zst'.format(pkg[0], pkg[1], arch)
+        p_any = '/var/cache/pacman/pkg/{}-{}-{}.pkg.tar.zst'.format(pkg[0], pkg[1], 'any')
+        if isfile(p_arch):
+            return tarfile.open(fileobj=zflat(p_arch), mode='r|*')
+        if isfile(p_any):
+            return tarfile.open(fileobj=zflat(p_any), mode='r|*')
         return None
 
     arch = run(['uname', '-m'], stdout=PIPE).stdout.decode().rstrip()


### PR DESCRIPTION
[Since january](https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/) Archlinux packages are compressed using `zstd`, not `xz`; this breaks the script currently (see #8).
This PR is somewhat dirty since it doesn't clean up the transient streams, but in practice this doesn't seem to be a problem (with 2k packages anyway), and the tool is meant to be run manually only.

The script now has a dependency on the `python-zstandard` package.